### PR TITLE
Add missing Lancache headers used by XXXPrefill applications

### DIFF
--- a/includes/proxy.conf
+++ b/includes/proxy.conf
@@ -1,3 +1,10 @@
+# Abort any circular requests
+if ($http_X_LanCache_Processed_By = $hostname) {
+  return 508;
+}
+proxy_set_header X-LanCache-Processed-By $hostname;
+add_header X-LanCache-Processed-By $hostname,$http_X_LanCache_Processed_By always;
+
 # Settings for proxying requests to upstream
 
 # Pass the entire request URI through to the upstream server

--- a/nginx.conf
+++ b/nginx.conf
@@ -96,6 +96,13 @@ http {
 
     # Server configuration for requests that don't match any of the caches
     server {
+        # Abort any circular requests
+        if ($http_X_LanCache_Processed_By = $hostname) {
+          return 508;
+        }
+        proxy_set_header X-LanCache-Processed-By $hostname;
+        add_header X-LanCache-Processed-By $hostname,$http_X_LanCache_Processed_By always;
+        
         # Listen for connections on any IP port 80 for requests that dont
         # match any of the other servers' server_name. Enable port sharding
         # with SO_REUSEPORT socket option, allowing each worker process to


### PR DESCRIPTION
Awesome project that did work with Steam without any problem.

**Problem :**
However i went to configure a SteamPrefill application on the same server where i deployed everything, with a custom ansible playbook, to prefill my games but it dit not work.

I tried to use SteamPrefill from my PC and got the same problem as the one on the server. After  further analysis it seems that the (Steam|Epic|BattleNet)Prefill applications check the lancache server existance by listening to a specific Header sent by it : **X-LanCache-Processed-By**

After comparing the configurations, it seems that they were missing here.

**Solution :**
This pull request adds the missing "X-LanCache-Processed-By" to the response sent by the server.
Every Prefill application works now (on local pc, on the server or any other place i call it)